### PR TITLE
Show description in ICS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 vendor
+config.inc.php
 

--- a/banner_ics.css
+++ b/banner_ics.css
@@ -64,3 +64,17 @@
     color: black;
 }
 
+.ics-event-description div {
+    padding: 0 !important;
+    margin: 0 !important;
+}
+
+.ics-event-description a {
+    display: inline-block;
+    max-width: 25em;
+    overflow: hidden;
+    white-space: nowrap;
+    text-overflow: ellipsis;
+    vertical-align: bottom;
+}
+

--- a/banner_ics.css
+++ b/banner_ics.css
@@ -64,6 +64,10 @@
     color: black;
 }
 
+.ics-event-description {
+    overflow-x: auto;
+}
+
 .ics-event-description div {
     padding: 0 !important;
     margin: 0 !important;

--- a/banner_ics.js
+++ b/banner_ics.js
@@ -1,0 +1,26 @@
+/*
+ * banner_ics plugin
+ * @author pulsejet
+ */
+
+window.rcmail && rcmail.addEventListener('message', function(evt) {
+    // Remove the button classes from the description links
+    $('div.ics-event-description a').each(function () {
+        const target = this;
+        const removeClasses = () => $(target).removeClass('btn button btn-sm btn-primary');
+        removeClasses();
+
+        // Ugly: Larry adds the "button" class unpredictably,
+        // so just observe the change and remove it
+        if ("MutationObserver" in window) {
+            new MutationObserver(function(mutations) {
+                mutations.forEach(function(mutation) {
+                    if (mutation.attributeName === 'class') {
+                        removeClasses();
+                    }
+                });
+            }).observe(target, { attributes: true, childList: true, characterData: true });
+        }
+    });
+});
+

--- a/banner_ics.js
+++ b/banner_ics.js
@@ -3,7 +3,7 @@
  * @author pulsejet
  */
 
-window.rcmail && rcmail.addEventListener('message', function(evt) {
+window.rcmail && rcmail.addEventListener('init', function(evt) {
     // Remove the button classes from the description links
     $('div.ics-event-description a').each(function () {
         const target = this;

--- a/banner_ics.php
+++ b/banner_ics.php
@@ -101,13 +101,11 @@
                      $html .= '<br/>' . htmlspecialchars($who);
                 }
                 if (self::SHOW_DESCR){
-                    $descript = nl2br($event->description);
-                    //For url in < >
-                    $descript = preg_replace('/&lt;(https?:\/\/(?:www\.|(?!www))[a-zA-Z0-9][a-zA-Z0-9-]+[a-zA-Z0-9]\.[^\s]{2,}|www\.[a-zA-Z0-9][a-zA-Z0-9-]+[a-zA-Z0-9]\.[^\s]{2,}|https?:\/\/(?:www\.|(?!www))[a-zA-Z0-9]+\.[^\s]{2,}|www\.[a-zA-Z0-9]+\.[^\s]{2,})&gt;/Ui', '<a href="$1" target="_blank">$1</a>', $descript);
-                    //For mailto:email
-                    $descript = preg_replace('/([\w\-\_\.]+@[\w-]+\.+[\w\.\-\_]+)&lt;mailto:([\w\-\_\.]+@[\w-]+\.+[\w\.\-\_]+)&gt;/Ui', '<a href="mailto:$1" target="_blank">$1</a>', $descript);
-                    $descript = preg_replace('/&lt;mailto:([\w\-\_\.]+@[\w-]+\.+[\w\.\-\_]+)&gt;/Ui', '<a href="mailto:$1" target="_blank">$1</a>', $descript);
-                    $html .= '<hr/>'.$descript.'<hr/>';
+                    $descript = str_replace("&gt;"," ",$event->description);
+                    $descript = str_replace("&lt;"," ",$descript);
+                    $descript = str_replace("mailto:","",$descript); //rcube_text2html ignores mailto: prefix but makes the link with it, therefore, we can delete mailto:
+                    $text2html = new rcube_text2html($descript, false, array());
+                    $html .= '<hr/>'.$text2html->get_html() .'<hr/>';
                 }
                 $html .= '</div>';
                 $html .= '</div>';

--- a/banner_ics.php
+++ b/banner_ics.php
@@ -101,9 +101,13 @@
                      $html .= '<br/>' . htmlspecialchars($who);
                 }
                 if (self::SHOW_DESCR){
-                     $descript = nl2br(htmlspecialchars($event->description));
-                     $descript = preg_replace('/&amp;lt;(.*)&amp;gt;/U', '<a href="$1" target="_blank">$1</a>', $descript);
-                     $html .= '<hr/>'.$descript.'<hr/>';
+                    $descript = nl2br($event->description);
+                    //For url in < >
+                    $descript = preg_replace('/&lt;(https?:\/\/(?:www\.|(?!www))[a-zA-Z0-9][a-zA-Z0-9-]+[a-zA-Z0-9]\.[^\s]{2,}|www\.[a-zA-Z0-9][a-zA-Z0-9-]+[a-zA-Z0-9]\.[^\s]{2,}|https?:\/\/(?:www\.|(?!www))[a-zA-Z0-9]+\.[^\s]{2,}|www\.[a-zA-Z0-9]+\.[^\s]{2,})&gt;/Ui', '<a href="$1" target="_blank">$1</a>', $descript);
+                    //For mailto:email
+                    $descript = preg_replace('/([\w\-\_\.]+@[\w-]+\.+[\w\.\-\_]+)&lt;mailto:([\w\-\_\.]+@[\w-]+\.+[\w\.\-\_]+)&gt;/Ui', '<a href="mailto:$1" target="_blank">$1</a>', $descript);
+                    $descript = preg_replace('/&lt;mailto:([\w\-\_\.]+@[\w-]+\.+[\w\.\-\_]+)&gt;/Ui', '<a href="mailto:$1" target="_blank">$1</a>', $descript);
+                    $html .= '<hr/>'.$descript.'<hr/>';
                 }
                 $html .= '</div>';
                 $html .= '</div>';

--- a/banner_ics.php
+++ b/banner_ics.php
@@ -106,7 +106,6 @@
                 }
                 $html .= '</div>';
                 $html .= '</div>';
-
                 array_push($content, $html);
 
                 // Optional description block

--- a/banner_ics.php
+++ b/banner_ics.php
@@ -14,6 +14,7 @@
     class banner_ics extends rcube_plugin
     {
         public $task = 'mail';
+		const SHOW_DESCR = true; // This variable controls to show or not description of event
 
         function init()
         {
@@ -99,6 +100,11 @@
                 if (isset($who)) {
                      $html .= '<br/>' . htmlspecialchars($who);
                 }
+				if (self::SHOW_DESCR){
+					$descript = nl2br(htmlspecialchars($event->description));
+					$descript = preg_replace('/&amp;lt;(.*)&amp;gt;/U', '<a href="$1" target="_blank">$1</a>', $descript);
+					$html .= '<hr/>'.$descript.'<hr/>';
+				}
                 $html .= '</div>';
                 $html .= '</div>';
                 array_push($content, $html);

--- a/banner_ics.php
+++ b/banner_ics.php
@@ -14,7 +14,7 @@
     class banner_ics extends rcube_plugin
     {
         public $task = 'mail';
-		const SHOW_DESCR = true; // This variable controls to show or not description of event
+        const SHOW_DESCR = true; // This variable controls to show or not description of event
 
         function init()
         {
@@ -100,11 +100,11 @@
                 if (isset($who)) {
                      $html .= '<br/>' . htmlspecialchars($who);
                 }
-				if (self::SHOW_DESCR){
-					$descript = nl2br(htmlspecialchars($event->description));
-					$descript = preg_replace('/&amp;lt;(.*)&amp;gt;/U', '<a href="$1" target="_blank">$1</a>', $descript);
-					$html .= '<hr/>'.$descript.'<hr/>';
-				}
+                if (self::SHOW_DESCR){
+                     $descript = nl2br(htmlspecialchars($event->description));
+                     $descript = preg_replace('/&amp;lt;(.*)&amp;gt;/U', '<a href="$1" target="_blank">$1</a>', $descript);
+                     $html .= '<hr/>'.$descript.'<hr/>';
+                }
                 $html .= '</div>';
                 $html .= '</div>';
                 array_push($content, $html);

--- a/banner_ics.php
+++ b/banner_ics.php
@@ -19,6 +19,7 @@
         function init()
         {
             $this->include_stylesheet('banner_ics.css');
+            $this->include_script('banner_ics.js');
             $this->add_hook('message_objects', array($this, 'ics_banner'));
         }
 
@@ -100,16 +101,20 @@
                 if (isset($who)) {
                      $html .= '<br/>' . htmlspecialchars($who);
                 }
-                if (self::SHOW_DESCR){
-                    $descript = str_replace("&gt;"," ",$event->description);
-                    $descript = str_replace("&lt;"," ",$descript);
-                    $descript = str_replace("mailto:","",$descript); //rcube_text2html ignores mailto: prefix but makes the link with it, therefore, we can delete mailto:
-                    $text2html = new rcube_text2html($descript, false, array());
-                    $html .= '<hr/>'.$text2html->get_html() .'<hr/>';
-                }
                 $html .= '</div>';
                 $html .= '</div>';
+
                 array_push($content, $html);
+
+                // Optional description block
+                if (self::SHOW_DESCR) {
+                     $html = '<div class="info ics-event-description">';
+                     $text2html = new rcube_text2html(htmlspecialchars_decode($event->description));
+                     $html .= $text2html->get_html();
+                     $html .= '</div>';
+
+                     array_push($content, $html);
+                }
             }
         }
     }

--- a/banner_ics.php
+++ b/banner_ics.php
@@ -14,12 +14,15 @@
     class banner_ics extends rcube_plugin
     {
         public $task = 'mail';
-        const SHOW_DESCR = true; // This variable controls to show or not description of event
 
         function init()
         {
+            $this->load_config('config.inc.php.dist');
+            $this->load_config('config.inc.php');
+
             $this->include_stylesheet('banner_ics.css');
             $this->include_script('banner_ics.js');
+
             $this->add_hook('message_objects', array($this, 'ics_banner'));
         }
 
@@ -107,7 +110,7 @@
                 array_push($content, $html);
 
                 // Optional description block
-                if (self::SHOW_DESCR) {
+                if ($rcmail->config->get('banner_ics_description')) {
                      $html = '<div class="info ics-event-description">';
                      $text2html = new rcube_text2html(htmlspecialchars_decode($event->description));
                      $html .= $text2html->get_html();

--- a/banner_ics.php
+++ b/banner_ics.php
@@ -111,10 +111,9 @@
                 // Optional description block
                 if ($rcmail->config->get('banner_ics_description')) {
                      $html = '<div class="info ics-event-description">';
-                     $text2html = new rcube_text2html(htmlspecialchars_decode($event->description));
-                     $html .= $text2html->get_html();
+                     $description = htmlspecialchars_decode($event->description);
+                     $html .= (new rcube_text2html($description))->get_html();
                      $html .= '</div>';
-
                      array_push($content, $html);
                 }
             }

--- a/config.inc.php.dist
+++ b/config.inc.php.dist
@@ -1,0 +1,7 @@
+<?php
+
+$config = array();
+
+// Show the description block
+$config['banner_ics_description'] = false;
+


### PR DESCRIPTION
Hi, this is a PR about issue #1, with that has a variable (const SHOW_DESCR = true) to show or not description, and it shows the non-html version (I didn't know how to access "X-ALT-DESC;FMTTYPE=text/html" in $event, and it's easier to use DESCRIPTION argument and add newlines and preg_replace to links
For me worked for teams invitations but I had a problem, href links shows as a button and in inspector says class="button", can be this disabled¿? Don't know why is adding it..
![image](https://user-images.githubusercontent.com/5132053/100855100-1b1dc880-348a-11eb-9308-1ecd560f7708.png)
