### PR TITLE
White text for elastic skin dark mode

### DIFF
--- a/banner_ics.css
+++ b/banner_ics.css
@@ -82,3 +82,6 @@
     vertical-align: bottom;
 }
 
+html.dark-mode .ics-event {
+    color: #c5d1d3;
+}


### PR DESCRIPTION
Dark mode defaults to dark background for the banner, so use contrasting text

PS: can we have a new release with the null array fix please?